### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@
 [我的新浪微博](http://weibo.com/alancheeen/profile?rightmod=1&wvr=6&mod=personinfo)
 
 
-##Apk 下载
+## Apk 下载
 [网页下载地址](http://fir.im/p3jf)
 
 
 
-##更新日志:
+## 更新日志:
 
 - 2015.6.22:
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
